### PR TITLE
edge-proxy - update to version 1.2.0-RC1

### DIFF
--- a/recipes-edge/edge-proxy/edge-proxy_git.bb
+++ b/recipes-edge/edge-proxy/edge-proxy_git.bb
@@ -26,7 +26,7 @@ edge-proxy-watcher.service \
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 SRCREV_FORMAT = "ep"
-SRCREV_ep = "d2e0fcdab1481487cab243c0ed3b4dc41febc49f"
+SRCREV_ep = "df50905bb0d35b74c81485c729adc8d9b9cb0516"
 GO_IMPORT = "github.com/PelionIoT/edge-proxy"
 
 RDEPENDS:${PN} = "jq bash"


### PR DESCRIPTION
Pull in 1.2.0-RC1.
- Update to golang 1.18
- Update to remote-dialer v1.0.4.
- Stop using older patched version of net, take latest via 1.18 golang itself.

Ref: https://github.com/PelionIoT/edge-proxy/tree/v1.2.0-RC1
- see commit history