### PR TITLE
edge-proxy - update to latest hash

### DIFF
--- a/recipes-edge/edge-proxy/edge-proxy_git.bb
+++ b/recipes-edge/edge-proxy/edge-proxy_git.bb
@@ -26,7 +26,7 @@ edge-proxy-watcher.service \
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 SRCREV_FORMAT = "ep"
-SRCREV_ep = "d2e0fcdab1481487cab243c0ed3b4dc41febc49f"
+SRCREV_ep = "856eadc308c613401664e7538a87a6973c05ef25"
 GO_IMPORT = "github.com/PelionIoT/edge-proxy"
 
 RDEPENDS:${PN} = "jq bash"


### PR DESCRIPTION
Takes to [PR#33](https://github.com/PelionIoT/edge-proxy/pull/33): ginkgo and gomega updates.
No expected functional changes, ginkgo and gomega are test frameworks.