### PR TITLE
pe-terminal update to v1.1.0

### DIFF
--- a/recipes-edge/edge-terminal/edge-terminal_1.1.0.bb
+++ b/recipes-edge/edge-terminal/edge-terminal_1.1.0.bb
@@ -22,7 +22,7 @@ file://config.json \
 
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-SRCREV = "v1.0.2"
+SRCREV = "v1.1.0"
 PV = "${SRCREV}+git${SRCPV}"
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "${RT_SERVICE_FILE} \
@@ -38,8 +38,6 @@ FILES:${PN} += "\
     ${EDGE_BIN}/edge-terminal\
     ${EDGE_ETC}/edge-terminal/config.json\
     "
-
-do_compile[network] = "1"
 
 do_compile() {
   cd src/${GO_IMPORT}


### PR DESCRIPTION
Vendor code included now in there, so no need to fetch code during do_compile anymore.