### PR TITLE
Add parsec service.

### DIFF
--- a/conf/machine/include/lmp-factory-custom.inc
+++ b/conf/machine/include/lmp-factory-custom.inc
@@ -36,10 +36,17 @@ kubelet \
 edge-proxy \
 "
 
+PARSEC_SERVICE = " \
+parsec-tool \
+parsec-service \
+"
+TOOLCHAIN:pn-parsec-service = "gcc"
+
 CORE_IMAGE_BASE_INSTALL:append = " \
 ${EDGE_BASE_REQUIRED} \
 ${EDGE_PROTOCOL_TRANSLATION} \
 ${EDGE_SYSTEMS_MANAGEMENT} \
 ${EDGE_CONTAINER_ORCHESTRATION} \
+${PARSEC_SERVICE} \
 "
 


### PR DESCRIPTION
Updated the CORE_IMAGE_BASE_INSTALL to include the parsecr-service and parsec-tool. This will use a Mbed Crypto provider by default.

Note that parsec-service doesn't compile with llvm, so gcc is selected for the TOOLCHAIN.