### PR TITLE
IZUMABL-260 fix coredns not building on inteli7

### DIFF
--- a/recipes-connectivity/coredns/coredns_1.8.3.bb
+++ b/recipes-connectivity/coredns/coredns_1.8.3.bb
@@ -23,9 +23,12 @@ SRCREV:pn-coredns = "v1.8.3"
 
 PR = "r1"
 
-DEPENDS = "git "
+DEPENDS += "git"
 RDEPENDS:${PN} += "bash "
 
+#CGO_LDFLAGS += "--sysroot=${WORKDIR}/recipe-sysroot -pthread"
+CGO_CFLAGS += "-I${WORKDIR}/recipe-sysroot/usr/include"
+CGO_FLAGS += "${@' '.join( filter( lambda x: x.startswith(( '-mfpu=', '-mfloat-abi=', '-mcpu=' )), d.getVar('CC').split(' ') ) )}"
 
 FILES:${PN} =  " \
     ${EDGE_BIN}/coredns\


### PR DESCRIPTION
CoreDNS is not building on inteli7 machine for some reason, some header files are not found (even though every arm target builds).

Found tips in: https://hackernoon.com/making-a-simple-service-app-for-a-yocto-based-linux-distro

Key fix is: `CGO_CFLAGS += "-I${WORKDIR}/recipe-sysroot/usr/include"`

Since it's the `cgo` compilation that fails and this points it to the right header files.
