### PR TITLE
Improve parsec security.

### DIFF
--- a/conf/machine/include/lmp-factory-custom.inc
+++ b/conf/machine/include/lmp-factory-custom.inc
@@ -42,6 +42,8 @@ parsec-tool \
 parsec-service \
 "
 TOOLCHAIN:pn-parsec-service = "gcc"
+# Add the parsec group to the ETC_GROUP_MEMBERS. This enables users to be added to the group at runtime, with either useradd or usermod
+ETC_GROUP_MEMBERS:append = " parsec"
 
 CORE_IMAGE_BASE_INSTALL:append = " \
 ${EDGE_BASE_REQUIRED} \

--- a/recipes-extended/parsec-service/files/parsec-tmpfiles.conf
+++ b/recipes-extended/parsec-service/files/parsec-tmpfiles.conf
@@ -1,0 +1,8 @@
+# This file is a copy of the one provided in
+# meta-security/meta-parsec/recipes-parsec/parsec-service/files
+# The difference is the Mode of /run/parsec is tightened to restrict access to
+# parsec to members of the parsec group.
+#
+#Type   Path            Mode    User    Group   Age     Argument
+d       /run/parsec     750     parsec  parsec  -       -
+d       /var/lib/parsec 700     parsec  parsec  -       -

--- a/recipes-extended/parsec-service/parsec-service_%.bbappend
+++ b/recipes-extended/parsec-service/parsec-service_%.bbappend
@@ -1,0 +1,3 @@
+# Force the use of our own version of files, instead of the base recipe.
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+


### PR DESCRIPTION
Tightened permissions of the /run/parsec folder to restrict access to users of the parsec group.
Enabled users to be added to the parsec group via useradd and usermod.