### PR TITLE
Add /etc/build to the image

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,3 +16,6 @@ TOOLCHAIN:pn-fluentbit = "gcc"
 TOOLCHAIN:pn-mbed-fcce = "gcc"
 CFLAGS:append:pn-edge-core = "-Wno-error=maybe-uninitialized"
 CFLAGS:remove:pn-edge-core = "-Werror=maybe-uninitialized"
+
+# Auto-populate /etc/build
+INHERIT += "image-buildinfo"


### PR DESCRIPTION
Force creation of /etc/build with all the layer SHA information, by inheriting image-buildinfo