### PR TITLE
GHAction: rm build fix for golang

### DIFF
--- a/.github/workflows/rm-build.yml
+++ b/.github/workflows/rm-build.yml
@@ -14,7 +14,11 @@ jobs:
           ls -al build
           df -h .
       - name: Remove build -folder
-        run: rm -rf build
+        run: |
+          # Due golang module policy, all external golang modules are READ ONLY
+          # so those can't be deleted unless you force them to be writable.
+          chmod u+w -R build
+          rm -rf build
       - name: Done
         run: |
           df -h .


### PR DESCRIPTION
Due to some inventive rules in golang community, all external golang modules are cloned over as READ ONLY. They cannot be deleted by normal means. Force them to be writable, so that the rm actually succeeds.

We have a step in the build to make the writable, but that only takes place if the build succeeds.