### PR TITLE
Add ostree integrity checking during BOOT.

### DIFF
--- a/recipes-core/images/initramfs-ostree-lmp-image.bbappend
+++ b/recipes-core/images/initramfs-ostree-lmp-image.bbappend
@@ -1,0 +1,1 @@
+PACKAGE_INSTALL:append = " initramfs-module-ostreecheck"

--- a/recipes-core/initrdscripts/initramfs-framework/ostreecheck
+++ b/recipes-core/initrdscripts/initramfs-framework/ostreecheck
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+# Initial concept of how to do OSTree fsck+diff to check
+# rootfs integrity.
+#
+# TODO:
+# - uncomment "fatal"s
+# - change various "msg" to "info"/"debug"
+# - verify validity of deployment hash via a signature
+# - verify version number to prevent rollback
+# - handling of /etc ?
+
+ostreecheck_enabled() {
+	return 0
+}
+
+ostreecheck_run() {
+	# We are running between ostree-prepare-root /rootfs and the move of
+	# that to /.
+
+	# In ostree 2021.1, ostree-prepare-root creates /run/ostree-booted, which
+	# confuses ostree commands run before the remount - they try to remount
+	# /sysroot, which doesn't exist yet.
+	# (Upstream ostree patch to avoid this pending at
+	# https://github.com/ostreedev/ostree/pull/2486 )
+	# Temporarily move the ostree-booted file (if it exists) to make it work.
+	mv /run/ostree-booted /run/ostree-booted.orig 2> /dev/null
+
+	msg "Checking OSTree repo"
+	/usr/bin/ostree fsck --repo=$ROOTFS_DIR/ostree/repo
+	if [ $? -ne 0 ]; then
+		msg "OSTree repo is damaged!"
+		#fatal
+	else
+		msg "OSTree repo intact"
+	fi
+
+	OSTREE_DEPLOY=`/usr/bin/ostree admin --sysroot=$ROOTFS_DIR --print-current-dir`
+	if [ $? -ne 0 ]; then
+		msg "OSTree admin --print-current-dir failed!"
+		return
+		#fatal
+	fi
+
+	# Extract revision ID from deployment path by
+	# stripping everything up to the last '/',
+	# and everything after the last '.'
+	ostree_rev="${OSTREE_DEPLOY##*/}"
+	ostree_rev="${ostree_rev%%.*}"
+	if [ -z "${ostree_rev}" ]; then
+		msg "No OSTree rev found!"
+		return 1
+		#fatal
+	fi
+
+	msg "Checking contents of OSTree deployment at ${OSTREE_DEPLOY}"
+	# For now just look for modified or deleted usr files
+	# (We would expect to see a bunch of added etc and var files.)
+	# grep returns 0 if any matches are found
+	/usr/bin/ostree diff --repo=$ROOTFS_DIR/ostree/repo ${ostree_rev} ${OSTREE_DEPLOY} | grep "[MD] *usr/"
+	if [ $? -eq 0 ]; then
+		msg "OSTree deployment modified!"
+		#fatal
+	else
+		msg "OSTree deployment intact"
+	fi
+
+	# Put back ostree-booted, if it existed.
+	mv /run/ostree-booted.orig /run/ostree-booted 2> /dev/null
+}

--- a/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+	file://ostreecheck \
+"
+
+PACKAGES:append = " initramfs-module-ostreecheck"
+
+SUMMARY_initramfs-module-ostreecheck = "initramfs support for ostree based filesystems"
+RDEPENDS:initramfs-module-ostreecheck = "${PN}-base ostree"
+FILES:initramfs-module-ostreecheck = "/init.d/985-ostreecheck"
+
+do_install:append() {
+	install -m 0755 ${WORKDIR}/ostreecheck ${D}/init.d/985-ostreecheck
+}


### PR DESCRIPTION
Added a script to perform and "ostree fsck" and "ostree diff" during device boot,

An error message will be printed if either check fails, but it doesn't prevent the boot.

The boot time is increased by about 60 seconds.