### PR TITLE
GHAction - fix license.manifest archiving

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
           tail -n 14 "$LOCALCONF"
           time bitbake ${{ inputs.image-type }}
           # Move the image_license.manifest to image folder so that we can archive in 1 step
-          mv deploy/licenses/${{ inputs.image-type }}-${{ inputs.target }}/*.manifest deploy/images/${{ inputs.target }}/
+          mv deploy/licenses/${{ inputs.image-type }}-${{ inputs.target }}/license.manifest deploy/images/${{ inputs.target }}/
       - name: Archive the developer cert wic-file & license manifest for ${{ inputs.target }}
         uses: actions/upload-artifact@v3
         with:
@@ -110,7 +110,7 @@ jobs:
           path: |
              build/build-lmp/deploy/images/${{ inputs.target }}/${{ inputs.image-type }}-${{ inputs.target }}.wic.bmap
              build/build-lmp/deploy/images/${{ inputs.target }}/${{ inputs.image-type }}-${{ inputs.target }}.wic.gz
-             build/build-lmp/deploy/images/${{ inputs.target }}/${{ inputs.image-type }}-${{ inputs.target }}/image_license.manifest
+             build/build-lmp/deploy/images/${{ inputs.target }}/license.manifest
           if-no-files-found: error
       - name: Build-BYOC ${{ inputs.target }}
         run: |
@@ -131,7 +131,7 @@ jobs:
           tail -n 14 "$LOCALCONF"
           time bitbake ${{ inputs.image-type }}
           # Move the image_license.manifest to image folder so that we can archive in 1 step
-          mv deploy/licenses/${{ inputs.image-type }}-${{ inputs.target }}/*.manifest deploy/images/${{ inputs.target }}/
+          mv deploy/licenses/${{ inputs.image-type }}-${{ inputs.target }}/license.manifest deploy/images/${{ inputs.target }}
       - name: Archive the BYOC WIC-file & license manifest for ${{ inputs.target }}
         uses: actions/upload-artifact@v3
         with:
@@ -139,7 +139,7 @@ jobs:
           path: |
               build/build-lmp/deploy/images/${{ inputs.target }}/${{ inputs.image-type }}-${{ inputs.target }}.wic.bmap
               build/build-lmp/deploy/images/${{ inputs.target }}/${{ inputs.image-type }}-${{ inputs.target }}.wic.gz
-              build/build-lmp/deploy/images/${{ inputs.target }}/${{ inputs.image-type }}-${{ inputs.target }}/image_license.manifest
+              build/build-lmp/deploy/images/${{ inputs.target }}/license.manifest
           if-no-files-found: error
       - name: Build-Factory ${{ inputs.target }}
         run: |
@@ -158,7 +158,7 @@ jobs:
           tail -n 14 "$LOCALCONF"
           time bitbake ${{ inputs.image-type }}
           # Move the image_license.manifest to image folder so that we can archive in 1 step
-          mv deploy/licenses/${{ inputs.image-type }}-${{ inputs.target }}/*.manifest deploy/images/${{ inputs.target }}/
+          mv deploy/licenses/${{ inputs.image-type }}-${{ inputs.target }}/license.manifest deploy/images/${{ inputs.target }}
       - name: Archive the Factory WIC-file & license manifest for ${{ inputs.target }}
         uses: actions/upload-artifact@v3
         with:
@@ -166,7 +166,7 @@ jobs:
           path: |
              build/build-lmp/deploy/images/${{ inputs.target }}/${{ inputs.image-type }}-${{ inputs.target }}.wic.bmap
              build/build-lmp/deploy/images/${{ inputs.target }}/${{ inputs.image-type }}-${{ inputs.target }}.wic.gz
-             build/build-lmp/deploy/images/${{ inputs.target }}/${{ inputs.image-type }}-${{ inputs.target }}/image_license.manifest
+             build/build-lmp/deploy/images/${{ inputs.target }}/license.manifest
           if-no-files-found: error
       - name: Build-PARSEC-Factory ${{ inputs.target }}
         run: |
@@ -186,7 +186,7 @@ jobs:
             tail -n 14 "$LOCALCONF"
             time bitbake ${{ inputs.image-type }}
             # Move the image_license.manifest to image folder so that we can archive in 1 step
-            mv deploy/licenses/${{ inputs.image-type }}-${{ inputs.target }}/*.manifest deploy/images/${{ inputs.target }}/
+            mv deploy/licenses/${{ inputs.image-type }}-${{ inputs.target }}/license.manifest deploy/images/${{ inputs.target }}
       - name: Archive the PARSEC Factory WIC-file & license manifest for ${{ inputs.target }}
         uses: actions/upload-artifact@v3
         with:
@@ -194,6 +194,6 @@ jobs:
             path: |
                build/build-lmp/deploy/images/${{ inputs.target }}/${{ inputs.image-type }}-${{ inputs.target }}.wic.bmap
                build/build-lmp/deploy/images/${{ inputs.target }}/${{ inputs.image-type }}-${{ inputs.target }}.wic.gz
-               build/build-lmp/deploy/images/${{ inputs.target }}/${{ inputs.image-type }}-${{ inputs.target }}/image_license.manifest
+               build/build-lmp/deploy/images/${{ inputs.target }}/license.manifest
             if-no-files-found: error
   


### PR DESCRIPTION
The license.manifest file is not ending up in the archive file.

https://github.com/PelionIoT/meta-edge/actions/runs/5334073525 -> that one has the license.manifest in it now, fix works.
