### PR TITLE
Fix verified logging feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Izuma Edge 2.6.1 - 3rd Oct 2023
+
+- [Verified logging](https://developer.izumanetworks.com/docs/device-management-edge/2.6/managing/verified-logging.html) - allows you to sign the logs in the device to prevent log manipulation.
+   - [journald] Enabled Forward Secure Sealing (FSS) feature of systemd journal.
+   - To configure Izuma Edge gateway with a sealing key and to keep track of the verification key in production setup, use Pelion Edge Provisioner (PEP) tool [v2.6.0](https://github.com/PelionIoT/pelion-edge-provisioner/releases/tag/v2.6.0).
+   - By default, the gateway is configured **with** persistent journal logging for LMP. To disable persistent logging, set flag `VOLATILE_LOG_DIR = "yes"` in `local.conf`, and update the `Storage` in recipes-core/systemd/systemd-conf/journald.conf. Note: If you disable persistent logging, the FSS feature won't work.
+

--- a/recipes-core/systemd/systemd-conf/journald.conf
+++ b/recipes-core/systemd/systemd-conf/journald.conf
@@ -1,0 +1,6 @@
+[Journal]
+ForwardToSyslog=yes
+RuntimeMaxUse=64M
+Storage=persistent
+SystemMaxUse=64M
+Seal=yes

--- a/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/recipes-core/systemd/systemd-conf_%.bbappend
@@ -1,0 +1,2 @@
+SUMMARY = "adds flags to journald.conf in a similar way to the method used by systemd-conf found in the systemd bitbake recipe"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,5 @@
+SUMMARY = "adds gcrypt (libgcrypt) to systemd binary for forward secure sealing (ffs) journald"
+PACKAGECONFIG:append = " gcrypt"
+
+# Disable systemd-resolved service
+PACKAGECONFIG:remove = " resolved nss-resolve"

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,5 +1,3 @@
 SUMMARY = "adds gcrypt (libgcrypt) to systemd binary for forward secure sealing (ffs) journald"
 PACKAGECONFIG:append = " gcrypt"
 
-# Disable systemd-resolved service
-PACKAGECONFIG:remove = " resolved nss-resolve"


### PR DESCRIPTION
The verified logging feature was accidentally removed during the creation of this layer and the 2.6.0 release.

See https://developer.izumanetworks.com/docs/device-management-edge/2.6/managing/verified-logging.html