### PR TITLE
Update edge-proxy and pe-terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Base LmP release updated to v91.
 - Update `pe-utils` to version 2.3.7.
     - `edge-testnet` is now detecting issues more accurately & more robustly.
+- Update `edge-proxy` to latest version (v.1.4.0).
+- UPdate `pe-terminal` to latest version (v1.2.0).
 
 # Izuma Edge 2.6.1 - 3rd Oct 2023
 

--- a/recipes-edge/edge-proxy/edge-proxy_git.bb
+++ b/recipes-edge/edge-proxy/edge-proxy_git.bb
@@ -26,7 +26,7 @@ edge-proxy-watcher.service \
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 SRCREV_FORMAT = "ep"
-SRCREV_ep = "d31d2ee582da510b38d9e5455530948747e94f9c"
+SRCREV_ep = "d02633b6146240932f6a5ef638b61d75e42cb1c3"
 GO_IMPORT = "github.com/PelionIoT/edge-proxy"
 
 RDEPENDS:${PN} = "jq bash"

--- a/recipes-edge/edge-terminal/edge-terminal_1.1.0.bb
+++ b/recipes-edge/edge-terminal/edge-terminal_1.1.0.bb
@@ -22,7 +22,7 @@ file://config.json \
 
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-SRCREV = "v1.1.0"
+SRCREV = "v1.2.0"
 PV = "${SRCREV}+git${SRCPV}"
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "${RT_SERVICE_FILE} \


### PR DESCRIPTION
Update `pe-terminal` and `edge-proxy` to latest.

NOTE! These require `golang 1.20`, so they might NOT build with the existing LmP version as is => turns out it's not a problem, it does build as expected.

## Todos

- [x] Git commits have clear descriptions
- [x] Reviewers set
- [x] Changelog updated
