### PR TITLE
CI: repo info & plain repo sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,8 @@ jobs:
             repo init -u https://github.com/PelionIoT/manifest-edge.git -m edge.xml -b refs/heads/${{ inputs.branch-manifest }}
           fi
           repo sync -j"$(nproc)" --force-sync meta-edge
+          echo "repo info" >>$GITHUB_STEP_SUMMARY
+          repo info >>$GITHUB_STEP_SUMMARY
           cd layers/meta-edge
           git fetch --all
           git checkout ${{ inputs.branch-meta-edge }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
             echo "${{ inputs.branch-manifest }} is a branch, using refs/heads/${{ inputs.branch-manifest }}"
             repo init -u https://github.com/PelionIoT/manifest-edge.git -m edge.xml -b refs/heads/${{ inputs.branch-manifest }}
           fi
-          repo sync -j"$(nproc)" --force-sync meta-edge
+          repo sync -j"$(nproc)"
           echo "repo info" >>$GITHUB_STEP_SUMMARY
           repo info >>$GITHUB_STEP_SUMMARY
           cd layers/meta-edge


### PR DESCRIPTION
CI related (build.yml) changes only:
* `repo info` to GITHUB_STEP_SUMMARY
* Use plain `repo sync`. 

## Todos

- [x] Git commits have clear descriptions
- [x] Reviewers set
- [N/A] Changelog updated -- not applicable, CI change.

